### PR TITLE
Remove Double `rootCmd.AddCommand(secretCmd.Cmd())`

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -37,7 +37,6 @@ func init() {
 	rootCmd.AddCommand(stageCmd.Cmd())
 	rootCmd.AddCommand(commandCmd.Cmd())
 	rootCmd.AddCommand(secretCmd.Cmd())
-	rootCmd.AddCommand(secretCmd.Cmd())
 	rootCmd.AddCommand(deployCmd.Cmd())
 	rootCmd.AddCommand(buildCmd.Cmd())
 


### PR DESCRIPTION
The secret command was added twice which prompts it to be shown twice in the help 

> Commands:
  build       Create a new build for the defined stage
  command     Interact with command invocations
  completion  Generate the autocompletion script for the specified shell
  deploy      Deploy the current build to AWS
  help        Help about any command
  secret      Work with secrets
  secret      Work with secrets
  stage       Work with stages

Just helping out with probably a copy/paste error